### PR TITLE
Modified deconv layers to agree with original arch

### DIFF
--- a/modelzoo/Unet.py
+++ b/modelzoo/Unet.py
@@ -35,22 +35,22 @@ def build_UNet(n_input_channels=1, BATCH_SIZE=None, num_output_classes=2, pad='s
 
     net['encode_1'] = batch_norm(ConvLayer(l, base_n_filters*16, 3, nonlinearity=nonlinearity, pad=pad, W=HeNormal(gain="relu")))
     net['encode_2'] = batch_norm(ConvLayer(net['encode_1'], base_n_filters*16, 3, nonlinearity=nonlinearity, pad=pad, W=HeNormal(gain="relu")))
-    net['upscale1'] = batch_norm(Deconv2DLayer(net['encode_2'], base_n_filters*16, 2, 2, crop="valid", nonlinearity=nonlinearity, W=HeNormal(gain="relu")))
+    net['upscale1'] = batch_norm(Deconv2DLayer(net['encode_2'], base_n_filters*8, 2, 2, crop="valid", nonlinearity=nonlinearity, W=HeNormal(gain="relu")))
 
     net['concat1'] = ConcatLayer([net['upscale1'], net['contr_4_2']], cropping=(None, None, "center", "center"))
     net['expand_1_1'] = batch_norm(ConvLayer(net['concat1'], base_n_filters*8, 3, nonlinearity=nonlinearity, pad=pad, W=HeNormal(gain="relu")))
     net['expand_1_2'] = batch_norm(ConvLayer(net['expand_1_1'], base_n_filters*8, 3, nonlinearity=nonlinearity, pad=pad, W=HeNormal(gain="relu")))
-    net['upscale2'] = batch_norm(Deconv2DLayer(net['expand_1_2'], base_n_filters*8, 2, 2, crop="valid", nonlinearity=nonlinearity, W=HeNormal(gain="relu")))
+    net['upscale2'] = batch_norm(Deconv2DLayer(net['expand_1_2'], base_n_filters*4, 2, 2, crop="valid", nonlinearity=nonlinearity, W=HeNormal(gain="relu")))
 
     net['concat2'] = ConcatLayer([net['upscale2'], net['contr_3_2']], cropping=(None, None, "center", "center"))
     net['expand_2_1'] = batch_norm(ConvLayer(net['concat2'], base_n_filters*4, 3, nonlinearity=nonlinearity, pad=pad, W=HeNormal(gain="relu")))
     net['expand_2_2'] = batch_norm(ConvLayer(net['expand_2_1'], base_n_filters*4, 3, nonlinearity=nonlinearity, pad=pad, W=HeNormal(gain="relu")))
-    net['upscale3'] = batch_norm(Deconv2DLayer(net['expand_2_2'], base_n_filters*4, 2, 2, crop="valid", nonlinearity=nonlinearity, W=HeNormal(gain="relu")))
+    net['upscale3'] = batch_norm(Deconv2DLayer(net['expand_2_2'], base_n_filters*2, 2, 2, crop="valid", nonlinearity=nonlinearity, W=HeNormal(gain="relu")))
 
     net['concat3'] = ConcatLayer([net['upscale3'], net['contr_2_2']], cropping=(None, None, "center", "center"))
     net['expand_3_1'] = batch_norm(ConvLayer(net['concat3'], base_n_filters*2, 3, nonlinearity=nonlinearity, pad=pad, W=HeNormal(gain="relu")))
     net['expand_3_2'] = batch_norm(ConvLayer(net['expand_3_1'], base_n_filters*2, 3, nonlinearity=nonlinearity, pad=pad, W=HeNormal(gain="relu")))
-    net['upscale4'] = batch_norm(Deconv2DLayer(net['expand_3_2'], base_n_filters*2, 2, 2, crop="valid", nonlinearity=nonlinearity, W=HeNormal(gain="relu")))
+    net['upscale4'] = batch_norm(Deconv2DLayer(net['expand_3_2'], base_n_filters, 2, 2, crop="valid", nonlinearity=nonlinearity, W=HeNormal(gain="relu")))
 
     net['concat4'] = ConcatLayer([net['upscale4'], net['contr_1_2']], cropping=(None, None, "center", "center"))
     net['expand_4_1'] = batch_norm(ConvLayer(net['concat4'], base_n_filters, 3, nonlinearity=nonlinearity, pad=pad, W=HeNormal(gain="relu")))


### PR DESCRIPTION
From the relevant paper, section no. 2: "Every step in the expansive path consists of an upsampling of the feature map followed by a 2x2 convolution ("up-convolution") THAT HALVES THE NUMBER OF FEATURE CHANNELS." Therefore, the number of features for all 'upscale' layers was cut in half. E.g.: 
net['encode_2'] = batch_norm(ConvLayer(... base_n_filters*16...)
net['upscale1'] = batch_norm(Deconv2DLayer(net['encode_2'], base_n_filters*16...)
was modified to:
net['encode_2'] = batch_norm(ConvLayer(... base_n_filters*16...)
net['upscale1'] = batch_norm(Deconv2DLayer(net['encode_2'], base_n_filters*8...)